### PR TITLE
Displacement conventions and other things

### DIFF
--- a/BAX150_userconfig.txt
+++ b/BAX150_userconfig.txt
@@ -1,0 +1,2 @@
+3.17 #maxstroke in microns
+0.43 #volume conversion factor

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # ALPAO-interface
-Interface to ALPAO DM-97
 
 To compile with the ASDK and milk [ImageStreamIO](https://github.com/milk-org/ImageStreamIO) libraries:
 	
 	gcc runALPAO.c -o build/runALPAO -L$HOME/milk/lib -I$HOME/milk/src/ImageStreamIO -limagestreamio -lasdk
+	
+Before running, set the path to the ALPAO configuration files and copy <serial>_userconfig.txt to the same direcotry:
+	
+	export ACECFG=$HOME/ALPAO/Config
+
+------------------------
 
 To enter the DM control loop with default settings:
 
 	./runALPAO <serialnumber>
 
-`ctrl+c` will exit the loop and safely reset and release the DM. To run with bias and normalization conventions disabled (not yet implemented):
+`ctrl+c` will exit the loop and safely reset and release the DM. To run with bias and normalization conventions disabled:
 
 	./runALPAO <serialnumber> --nobias --nonorm
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To compile with the ASDK and milk [ImageStreamIO](https://github.com/milk-org/Im
 	
 	gcc runALPAO.c -o build/runALPAO -L$HOME/milk/lib -I$HOME/milk/src/ImageStreamIO -limagestreamio -lasdk
 	
-Before running, set the path to the ALPAO configuration files and copy <serial>_userconfig.txt to the same direcotry:
+Before running, set the path to the ALPAO configuration files and copy \<serial\>_userconfig.txt to the same direcotry:
 	
 	export ACECFG=$HOME/ALPAO/Config
 

--- a/runALPAO.c
+++ b/runALPAO.c
@@ -141,7 +141,7 @@ int controlLoop(char * serial, int nobias, int nonorm)
     // set DM to all-0 state to begin
     printf("ALPAO %s: initializing all actuators to 0.\n", serial);
     ImageStreamIO_semwait(&SMimage[0], 0);
-    ret = sendCommand(dm, SMimage, nbAct);
+    ret = sendCommand(dm, SMimage, nbAct, nobias, nonorm);
     if (ret == -1)
     {
         return -1;

--- a/runALPAO.c
+++ b/runALPAO.c
@@ -17,9 +17,12 @@ Connects to the ALPAO DM (indicated by its serial number), initializes the
 shared memory image (if it doesn't already exist), and then commands the DM
 from the image when the associated semaphores post.
 
+Requires:
+export ACECFG=$HOME/ALPAO/Config
+where Config contains the ALPAO configuration files as well as the user-defined
+calibration file <serial>_userconfig.txt
+
 Still to be implemented or determined:
--Bias and displacement (though placeholder functions exist)
--Mapping from normalized ASDK inputs (-1 -> +1) to physical displacement
 -Multiplexed virtual DM
 */
 
@@ -278,7 +281,7 @@ int controlLoop(char * serial, int nobias, int nonorm)
     {
         return -1;
     }
-    
+
     //initialize DM
     asdkDM * dm = NULL;
     dm = asdkInit(serial);


### PR DESCRIPTION
* Remove DC offset in actuator inputs (disable with `--nobias` flag)
* Normalize displacement to height of cuboid with the same volume as influence function (disable with `--nonorm` flag)
* Inputs now expected in microns of displacement and converted to fractional stroke behind the scenes
* Volume normalization and stroke factor are set in `$ACECFG/<serial>_userconfig.txt`. Currently populated with rough estimates.
* Inputs are checked for out-of-bounds values and clipped to -1 to +1 range (fractional stroke) before commands are sent to the DM
* And a few miscellaneous cleanups.

Addresses all points in #2 except the multiplexed/virtual DM.