### PR TITLE
Fractional stroke option and querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ To enter the DM control loop with default settings:
 
 	./runALPAO <serialnumber>
 
-`ctrl+c` will exit the loop and safely reset and release the DM. To run with bias and normalization conventions disabled:
+`ctrl+c` will exit the loop and safely reset and release the DM. To run with bias and normalization conventions disabled and inputs in fractional stroke:
 
-	./runALPAO <serialnumber> --nobias --nonorm
+	./runALPAO <serialnumber> --nobias --nonorm --fractional
 
 For help:
 
 	./runALPAO --help
 
-Once the control loop is running, the DM can be commanded by writing a 97x1 image to shared memory using your tool of choice. A few examples using the milk package are provided:
+Once the control loop is running, the DM can be commanded by writing a 97x1 image to shared memory using your tool of choice. By default, double-precision inputs are expected in microns of stroke. A few examples using the milk package are provided:
 
 	./loadfits <path-to-fits-file> <serial>
 	./setpix <value> <actuator-number> <serial>

--- a/queryALPAO.c
+++ b/queryALPAO.c
@@ -1,0 +1,60 @@
+/*
+To compile:
+>>>gcc queryALPAO.c -o build/queryALPAO -L$HOME/milk/lib -I$HOME/milk/src/ImageStreamIO -limagestreamio
+(You must already have milk installed.)
+
+To call:
+>>>build/./queryALPAO <serial>
+
+Prints out the value of each actuator input from the shared
+memory image corresponding to an ALPAO DM, which should
+directly correspond to the real actuator stroke state if
+the DM is in use.
+*/
+
+/* System Headers */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stddef.h>
+
+/* milk */
+#include "ImageStruct.h"   // cacao data structure definition
+#include "ImageStreamIO.h" // function ImageStreamIO_read_sharedmem_image_toIMAGE()
+
+/* Reset and Release */
+int query_shared_memory(char * serial)
+{
+	IMAGE * SMimage;
+	int idx;
+	int nbAct;
+
+	// connect to shared memory image
+    SMimage = (IMAGE*) malloc(sizeof(IMAGE));
+    ImageStreamIO_read_sharedmem_image_toIMAGE(serial, &SMimage[0]);
+
+    // print out stroke of each actuator
+    nbAct = SMimage[0].md[0].size[0];
+    for ( idx = 0 ; idx < nbAct ; idx++)
+    {
+        printf("%s actuator #%d: %lf\n", serial, idx+1, SMimage[0].array.D[idx]);
+    }
+
+    return 0;
+}
+
+/* Main program */
+int main( int argc, char ** argv )
+{
+    char * serial;
+
+    if (argc < 2)
+    {
+        printf("Serial number must be supplied.\n");
+        return -1;
+    }
+    serial = argv[1];
+
+    int ret = query_shared_memory(serial);
+    return ret;
+}


### PR DESCRIPTION
This PR adds the `--fractional` option to command in fractional stroke (which, when combined with `--nobias` and `--nonorm`, allows feeding inputs directly into the ALPAO SDK with no preprocessing [apart from clipping for safety reasons]). Also adds the `queryALPAO` script to easily check actuator states for an ALPAO DM currently in use.