### PR TITLE
Double -> Float

### DIFF
--- a/loadfits
+++ b/loadfits
@@ -1,5 +1,5 @@
 #Usage: ./loadfits /path/to/fitsfile.fits serial
-milk << EOF
+cacao << EOF
 loadfits "$1" im
 readshmim $2
 cp im $2

--- a/runALPAO.c
+++ b/runALPAO.c
@@ -1,6 +1,7 @@
 /*
 To compile:
->>>gcc runALPAO.c -o build/runALPAO -L$HOME/milk/lib -I$HOME/milk/src/ImageStreamIO -limagestreamio -lasdk
+>>>gcc runALPAO.c -o build/runALPAO -lImageStreamIO -lasdk -lpthread -lrt
+
 (You must already have the ALPAO SDK and milk installed.)
 
 Usage:
@@ -73,7 +74,7 @@ void initializeSharedMemory(char * serial, UInt nbAct)
     
     // image will be float type
     // see file ImageStruct.h for list of supported types
-    atype = _DATATYPE_DOUBLE;
+    atype = _DATATYPE_FLOAT;
     // image will be in shared memory
     shared = 1;
     // allocate space for 10 keywords
@@ -90,7 +91,7 @@ void initializeSharedMemory(char * serial, UInt nbAct)
     int i;
     for (i = 0; i < nbAct; i++)
     {
-      SMimage[0].array.D[i] = 0.;
+      SMimage[0].array.F[i] = 0.;
     }
 
     // post all semaphores
@@ -228,10 +229,12 @@ int sendCommand(asdkDM * dm, IMAGE * SMimage, int nbAct, int nobias, int nonorm,
     Scalar * dminputs;
 
     // Cast to array type ALPAO expects
+    // Scalar = double
+    // Shared memory image = float
     dminputs = (Scalar*) calloc( nbAct, sizeof( Scalar ) );
     for ( idx = 0 ; idx < nbAct ; idx++ )
     {
-        dminputs[idx] = SMimage[0].array.D[idx];
+        dminputs[idx] = (Scalar)SMimage[0].array.F[idx];
     }
 
     // First, convert raw displacements to volume-normalized displacements (microns)

--- a/setpix
+++ b/setpix
@@ -1,7 +1,7 @@
 #Usage: ./setpix val actnum serial
-milk << EOF
+cacao << EOF
 readshmim $3
-creaim im1 d 97 1
+creaim im1 97 1
 setpix im1 $1 $2 1 
 cp im1 $3
 exit


### PR DESCRIPTION
Changes the shared memory image to float, and then converts to double (Scalar in the ALPAO SDK) to pass the commands to the ALPAO.